### PR TITLE
Fix deprecation warning with avy--process

### DIFF
--- a/ace-jump-helm-line.el
+++ b/ace-jump-helm-line.el
@@ -439,7 +439,7 @@ Used for `ace-jump-helm-line'.")
                    ace-jump-helm-line-autoshow-use-linum
                    (linum-mode -1))
               (and (numberp
-                    (avy--process (ace-jump-helm-line--collect-lines
+                    (avy-process (ace-jump-helm-line--collect-lines
                                    (window-start)
                                    (window-end (selected-window) t))
                                   (avy--style-fn avy-style)))


### PR DESCRIPTION
Replaces `avy--process` with `avy-process`.

Not tested, although it should be fine, since according to https://oremacs.com/2019/05/11/avy-0.5.0/ `avy-process` is a "drop-in replacement."